### PR TITLE
De-emphasize English grammar; promote fluency

### DIFF
--- a/api-design-guidelines/index.md
+++ b/api-design-guidelines/index.md
@@ -330,10 +330,8 @@ is printed.
   {{enddetail}}
 
 
-### Strive for Fluent Usage
-
 * **Prefer method and function names that make use sites form
-  grammatical English phrases.** 
+  English phrases.** 
   {:#methods-and-functions-read-as-phrases}
   
   {{expand}}
@@ -361,6 +359,8 @@ is printed.
     **options: [.inProcess], completionHandler: stopProgressBar**)
   ~~~
   {{enddetail}}
+
+### Strive for Fluent Usage
 
 * **Begin names of factory methods with “`make`”,**
   e.g. `x.makeIterator()`.


### PR DESCRIPTION
The emphasis on “**gramatical** English phrases” creates a red herring that sidetracks Swift Evolution process into prolonged bikeshedding of names. The main leverage for achieving clarity at the use site, when designing new API, is provided by [Fluent Interface](https://martinfowler.com/bliki/FluentInterface.html) programming style and not the overzealous application of English grammar.

This change basically reverts the https://github.com/apple/swift-internals/commit/dc661fd60503452a4b82c6f5f7393eb8679aca39 by moving the principle into previous section and removes the word ‘grammatical’.